### PR TITLE
fix: resolved project live urls issue

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,2 @@
-api_key.py
 __pycache__/
 .streamlit/secrets.toml


### PR DESCRIPTION
The deployed Streamlit app fails due to missing GOOGLE_API_KEY in secrets.

Steps to fix:
- Add API key in Streamlit Cloud Secrets
- Ensure proper error handling if key is missing

Acceptance Criteria:
- App runs without KeyError
- Proper error message if key is missing