### PR TITLE
feat: add loading spinner during AI analysis

### DIFF
--- a/app.py
+++ b/app.py
@@ -83,7 +83,8 @@ if submit_button:
     ]
 
     st.image(image_data, width=300)
-    response = model.generate_content(prompt_parts)
+    with st.spinner("Analyzing image..."):
+        response = model.generate_content(prompt_parts)
     if response:
         st.title("Here is the analysis based on your image")
         st.write(response.text)


### PR DESCRIPTION
## Summary

Fixes #2

- Wraps the `model.generate_content()` call with `st.spinner("Analyzing image...")` so users see visual feedback while the AI processes the image
- Spinner appears as soon as analysis starts and disappears once the response is received

## Changes

`app.py` - wrapped the API call with `st.spinner()`:

```python
with st.spinner("Analyzing image..."):
    response = model.generate_content(prompt_parts)
```

## Test plan

- [ ] Upload a medical image and click "Generate the Analysis"
- [ ] Confirm spinner with "Analyzing image..." message appears during processing
- [ ] Confirm spinner disappears and results render correctly after response