### PR TITLE
Fix : Gemini SDK integration and update setup instructions

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,5 +1,5 @@
 import streamlit as st
-from google import genai
+import google.generativeai as genai
 import re
 from PIL import Image
 import io
@@ -10,7 +10,7 @@ if "GOOGLE_API_KEY" not in st.secrets:
     st.stop()
 
 # ================= CLIENT =================
-client = genai.Client(api_key=st.secrets["GOOGLE_API_KEY"])
+client = genai.configure(api_key=st.secrets["GOOGLE_API_KEY"])
 
 generation_config = {
     "temperature": 0.4,


### PR DESCRIPTION
# Changes Made
- Replaced `from google import genai` with `import google.generativeai as genai`
- Replaced unsupported `genai.Client()` usage with `genai.configure()`
- Updated Gemini model initialization to use `GenerativeModel`
- Updated content generation flow to match `google-generativeai` syntax

# Why This Change Was Needed
The project was using import and client syntax from the newer `google-genai` package while `requirements.txt` included `google-generativeai`.

This caused:
- Import errors
- Attribute errors
- Local setup issues
- Deployment failures

# Result
The app now runs correctly with the dependencies already listed in `requirements.txt`, and contributors can set up the project locally without additional confusion.

Fixed #22 