### PR TITLE
fix(reliability): enforce maximum history size to prevent unbounded disk consumption

### DIFF
--- a/history_manager.py
+++ b/history_manager.py
@@ -6,6 +6,7 @@ from datetime import datetime
 HISTORY_DIR = "history"
 METADATA_FILE = os.path.join(HISTORY_DIR, "metadata.json")
 IMAGES_DIR = os.path.join(HISTORY_DIR, "images")
+MAX_HISTORY_SIZE = 50
 
 def ensure_history_dirs():
     if not os.path.exists(IMAGES_DIR):
@@ -20,12 +21,12 @@ def save_to_history(image, confidence, clean_text, filename):
                 history = json.load(f)
         except:
             history = []
-    
+
     timestamp = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
     image_id = str(uuid.uuid4())
     image_path = os.path.join(IMAGES_DIR, f"{image_id}.png")
     image.save(image_path)
-    
+
     entry = {
         "id": image_id,
         "timestamp": timestamp,
@@ -34,8 +35,20 @@ def save_to_history(image, confidence, clean_text, filename):
         "confidence": confidence,
         "text": clean_text
     }
-    
-    history.insert(0, entry) # Most recent first
+
+    history.insert(0, entry)
+
+    if len(history) > MAX_HISTORY_SIZE:
+        evicted_entries = history[MAX_HISTORY_SIZE:]
+        history = history[:MAX_HISTORY_SIZE]
+        for evicted in evicted_entries:
+            image_file = evicted.get("image_path")
+            if image_file and os.path.exists(image_file):
+                try:
+                    os.remove(image_file)
+                except:
+                    pass
+
     with open(METADATA_FILE, "w") as f:
         json.dump(history, f, indent=4)
     return entry


### PR DESCRIPTION
## Summary

Closes #49

`save_to_history()` in `history_manager.py` had no limit on the number of stored history entries or image files. Over time, both `metadata.json` and `history/images/` would grow without bound, eventually exhausting available disk space on the deployment server.

Additionally, `load_history()` parses the entire JSON file on every page load, causing progressive performance degradation as the file grows.

## Root Cause

The function read the full history list, prepended the new entry, and wrote it back, with no eviction policy:

```python
history.insert(0, entry)
with open(METADATA_FILE, "w") as f:
    json.dump(history, f, indent=4)
```

No limit existed on the number of entries, and old image files were never deleted.

## Solution

Implemented a rolling-window history with a configurable size limit:

1. Added `MAX_HISTORY_SIZE = 50` constant to cap the number of stored entries
2. After inserting the new entry, check if history exceeds the limit
3. If it does, evict oldest entries (at the end of the list, since most recent is first)
4. Delete the image files for evicted entries to free disk space
5. Write the trimmed history back to metadata.json

```python
if len(history) > MAX_HISTORY_SIZE:
    evicted_entries = history[MAX_HISTORY_SIZE:]
    history = history[:MAX_HISTORY_SIZE]
    for evicted in evicted_entries:
        image_file = evicted.get("image_path")
        if image_file and os.path.exists(image_file):
            try:
                os.remove(image_file)
            except:
                pass
```

## Benefits

- **Disk space:** Prevents unbounded growth of `metadata.json` and `history/images/`, protecting deployments from disk exhaustion
- **Performance:** Keeps JSON parsing and serialization fast by limiting file size
- **Maintenance:** Rolling window automatically cleans old entries without manual intervention
- **User experience:** Users retain their 50 most recent analyses while older ones are automatically cleaned up

## Files Changed

- `history_manager.py` - Added MAX_HISTORY_SIZE constant and eviction logic to save_to_history()

## Testing

- [ ] Verify that analyzing images up to the limit (50) works normally
- [ ] Verify that the 51st analysis evicts the oldest entry
- [ ] Verify that the associated image file is deleted when an entry is evicted
- [ ] Verify that metadata.json remains at or below the size limit after many analyses
- [ ] Verify that `load_history()` and page load times remain consistent

## Program

This contribution is submitted under **NSoC 2026** (Nexus Spring of Code).

> **Note to maintainer:** Could you please add the `NSOC 2026` label to this PR? Thank you!